### PR TITLE
create library-item-versions when S3 uploads complete

### DIFF
--- a/core/migrations/2020-08-02-232057_add_type_to_library_item_version/down.sql
+++ b/core/migrations/2020-08-02-232057_add_type_to_library_item_version/down.sql
@@ -1,0 +1,13 @@
+DROP TABLE library_item_versions;
+CREATE TABLE library_item_versions (
+    id                SERIAL PRIMARY KEY,
+    api_id            VARCHAR UNIQUE NOT NULL,
+    user_id           INT NOT NULL,
+    library_item_id   INT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    asset_url         VARCHAR UNIQUE NOT NULL DEFAULT '',
+
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (library_item_id) REFERENCES library_items (id)
+);
+

--- a/core/migrations/2020-08-02-232057_add_type_to_library_item_version/up.sql
+++ b/core/migrations/2020-08-02-232057_add_type_to_library_item_version/up.sql
@@ -1,0 +1,15 @@
+DROP TABLE library_item_versions;
+CREATE TABLE library_item_versions (
+    id                    SERIAL PRIMARY KEY,
+    api_id                VARCHAR UNIQUE NOT NULL,
+    user_id               INT NOT NULL,
+    library_item_id       INT NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version_type          VARCHAR NOT NULL,
+    asset_url             VARCHAR,
+    asset_file_size_bytes BIGINT,
+    asset_data            JSONB,
+
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    FOREIGN KEY (library_item_id) REFERENCES library_items (id)
+);

--- a/core/src/auth/models/user.rs
+++ b/core/src/auth/models/user.rs
@@ -42,7 +42,7 @@ impl UserCreateSpec {
             .map_err(ApiError::DatabaseError)?)
     }
 }
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct ApiUserCreateSpec {
     #[serde(rename = "emailAddress")]
     pub email_address: String,

--- a/core/src/jobs/job_type.rs
+++ b/core/src/jobs/job_type.rs
@@ -5,11 +5,11 @@ use diesel::Expression;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum JobType {
-    SYSTEM,
+    System,
 }
 
 impl fmt::Display for JobType {
-    // TODO: write macro to add Debug and this impl
+    // TODO: write macro to add Debug and this impl? or improve in some other way
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let type_str = format!("{:?}", self);
         write!(f, "{}", type_str.to_ascii_lowercase())

--- a/core/src/library/filters.rs
+++ b/core/src/library/filters.rs
@@ -1,9 +1,7 @@
 use crate::db::DbPool;
 use crate::library::handlers;
 use crate::library::handlers::{
-    ApiLibraryItemBulkCreateSpec,
-    ApiLibraryItemUpdateSpec,
-    // ApiLibraryItemVersionCreateSpec,
+    ApiLibraryItemBulkCreateSpec, ApiLibraryItemUpdateSpec, ApiLibraryItemVersionCreateSpec,
 };
 use crate::routes::{json_body, with_db, with_session};
 use crate::utils::list_options::ListOptions;
@@ -77,14 +75,14 @@ pub fn library_item_delete(
         .and_then(handlers::delete_library_item)
 }
 
-// /// POST /library-item-version with JSON body
-// pub fn library_item_version_create(
-//     db_pool: DbPool,
-// ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-//     warp::path!("library-item-version")
-//         .and(warp::post())
-//         .and(json_body::<ApiLibraryItemVersionCreateSpec>())
-//         .and(with_session(db_pool.clone()))
-//         .and(with_db(db_pool))
-//         .and_then(handlers::create_library_item_version)
-// }
+/// POST /library-item-version with JSON body
+pub fn library_item_version_create(
+    db_pool: DbPool,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("library-item-version")
+        .and(warp::post())
+        .and(json_body::<ApiLibraryItemVersionCreateSpec>())
+        .and(with_session(db_pool.clone()))
+        .and(with_db(db_pool))
+        .and_then(handlers::create_library_item_version)
+}

--- a/core/src/library/filters.rs
+++ b/core/src/library/filters.rs
@@ -14,7 +14,8 @@ pub fn routes(
         .or(library_item_get(db_pool.clone()))
         .or(library_item_create(db_pool.clone()))
         .or(library_item_update(db_pool.clone()))
-        .or(library_item_delete(db_pool))
+        .or(library_item_delete(db_pool.clone()))
+        .or(library_item_version_create(db_pool))
 }
 
 /// GET /library-item?offset=3&limit=5

--- a/core/src/library/handlers.rs
+++ b/core/src/library/handlers.rs
@@ -226,12 +226,16 @@ fn run_create_library_item_version(
     let library_item = LibraryItem::find(conn, session.user_id, spec.library_item_api_id)?;
     // TODO: generate CloudFront URL for LibraryItemVersion (using library_item.{name,api_id})
     // let library_item_version_url = format!("https://assets.westrik.world/{}-{}", library_item.name, library_item.api_id);
-    Ok(LibraryItemVersion::create(
+    let library_item_version = LibraryItemVersion::create(
         conn,
         session.user_id,
         library_item,
-        None // Some(library_item_version_url),
-    )?)
+        None, // Some(library_item_version_url),
+    )?;
+    // TODO: enqueue library item processing job for library_item_version.id
+    //  - should load library_item and library_item_version, then get file metadata from S3
+    //  - call Lambda API endpoints to run relevant processing jobs
+    Ok(library_item_version)
 }
 
 pub async fn create_library_item_version(

--- a/core/src/library/handlers.rs
+++ b/core/src/library/handlers.rs
@@ -239,7 +239,7 @@ pub async fn create_library_item_version(
     session: Session,
     db_pool: DbPool,
 ) -> Result<impl warp::Reply, Rejection> {
-    debug!("create_library_item: spec={:?}", spec);
+    debug!("create_library_item_version: spec={:?}", spec);
     let library_item_version = run_create_library_item_version(spec, session, &db_pool)?;
     Ok(warp::reply::with_status(
         warp::reply::json(&CreateLibraryItemVersionResponse {

--- a/core/src/library/handlers.rs
+++ b/core/src/library/handlers.rs
@@ -71,8 +71,6 @@ pub struct CreateLibraryItemVersionResponse {
 pub struct ApiLibraryItemVersionCreateSpec {
     #[serde(rename = "libraryItemId")]
     library_item_api_id: String,
-    #[serde(rename = "assetUrl")]
-    asset_url: String,
 }
 
 fn run_get_library_items(session: Session, pool: &DbPool) -> Result<Vec<LibraryItem>, ApiError> {
@@ -226,11 +224,13 @@ fn run_create_library_item_version(
 ) -> Result<LibraryItemVersion, ApiError> {
     let conn = &get_conn(&db_pool).unwrap();
     let library_item = LibraryItem::find(conn, session.user_id, spec.library_item_api_id)?;
+    // TODO: generate CloudFront URL for LibraryItemVersion (using library_item.{name,api_id})
+    // let library_item_version_url = format!("https://assets.westrik.world/{}-{}", library_item.name, library_item.api_id);
     Ok(LibraryItemVersion::create(
         conn,
         session.user_id,
         library_item,
-        Some(spec.asset_url),
+        None // Some(library_item_version_url),
     )?)
 }
 

--- a/core/src/library/handlers.rs
+++ b/core/src/library/handlers.rs
@@ -3,6 +3,7 @@ use crate::db::{get_conn, DbPool};
 use crate::errors::ApiError;
 use crate::library::models::library_item::{LibraryItem, LibraryItemCreateSpec};
 // use crate::library::models::library_item_version::LibraryItemVersion;
+use crate::library::models::library_item_version::LibraryItemVersion;
 use crate::resource_identifier::{generate_resource_identifier, ResourceType};
 use crate::s3::put_object_request::generate_presigned_upload_url;
 use crate::utils::list_options::ListOptions;
@@ -59,14 +60,26 @@ pub struct UpdateLibraryItemResponse {
     upload_url: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct CreateLibraryItemVersionResponse {
+    error: Option<String>,
+    #[serde(rename = "libraryItemVersion")]
+    library_item_version: Option<LibraryItemVersion>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ApiLibraryItemVersionCreateSpec {
-    #[serde(rename = "fileSizeInBytes")]
-    pub file_size_in_bytes: Option<i32>,
+    #[serde(rename = "libraryItemId")]
+    library_item_api_id: String,
+    #[serde(rename = "assetUrl")]
+    asset_url: String,
 }
 
 fn run_get_library_items(session: Session, pool: &DbPool) -> Result<Vec<LibraryItem>, ApiError> {
-    Ok(LibraryItem::find_all(&get_conn(&pool).unwrap(), session)?)
+    Ok(LibraryItem::find_all(
+        &get_conn(&pool).unwrap(),
+        session.user_id,
+    )?)
 }
 
 pub async fn list_library_items(
@@ -92,7 +105,7 @@ fn run_get_library_item(
 ) -> Result<LibraryItem, ApiError> {
     Ok(LibraryItem::find(
         &get_conn(&pool).unwrap(),
-        session,
+        session.user_id,
         api_id,
     )?)
 }
@@ -172,8 +185,8 @@ fn run_update_library_item(
     pool: &DbPool,
 ) -> Result<LibraryItem, ApiError> {
     Ok(LibraryItem::update(
-        session,
         &get_conn(&pool).unwrap(),
+        session.user_id,
         api_id,
         spec.name,
     )?)
@@ -206,30 +219,33 @@ pub async fn delete_library_item(
     Ok(StatusCode::NO_CONTENT)
 }
 
-// fn run_create_library_item_version(
-//     spec: ApiLibraryItemVersionCreateSpec,
-//     session: Session,
-//     db_pool: &DbPool,
-// ) -> Result<LibraryItem, ApiError> {
-//     Ok(LibraryItemVersion::create(
-//         &get_conn(&db_pool).unwrap(),
-//         session,
-//         spec.name,
-//     )?)
-// }
-//
-// pub async fn create_library_item_version(
-//     spec: ApiLibraryItemVersionCreateSpec,
-//     session: Session,
-//     db_pool: DbPool,
-// ) -> Result<impl warp::Reply, Rejection> {
-//     debug!("create_library_item: spec={:?}", spec);
-//     let library_item = run_create_library_item(spec, session, &db_pool)?;
-//     Ok(warp::reply::with_status(
-//         warp::reply::json(&UpdateLibraryItemResponse {
-//             error: None,
-//             library_item: Some(library_item),
-//         }),
-//         StatusCode::OK,
-//     ))
-// }
+fn run_create_library_item_version(
+    spec: ApiLibraryItemVersionCreateSpec,
+    session: Session,
+    db_pool: &DbPool,
+) -> Result<LibraryItemVersion, ApiError> {
+    let conn = &get_conn(&db_pool).unwrap();
+    let library_item = LibraryItem::find(conn, session.user_id, spec.library_item_api_id)?;
+    Ok(LibraryItemVersion::create(
+        conn,
+        session.user_id,
+        library_item,
+        Some(spec.asset_url),
+    )?)
+}
+
+pub async fn create_library_item_version(
+    spec: ApiLibraryItemVersionCreateSpec,
+    session: Session,
+    db_pool: DbPool,
+) -> Result<impl warp::Reply, Rejection> {
+    debug!("create_library_item: spec={:?}", spec);
+    let library_item_version = run_create_library_item_version(spec, session, &db_pool)?;
+    Ok(warp::reply::with_status(
+        warp::reply::json(&CreateLibraryItemVersionResponse {
+            error: None,
+            library_item_version: Some(library_item_version),
+        }),
+        StatusCode::OK,
+    ))
+}

--- a/core/src/library/models/library_item.rs
+++ b/core/src/library/models/library_item.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use diesel::insert_into;
 use diesel::prelude::*;
 
-use crate::auth::models::session::Session;
 use crate::auth::models::user::User;
 use crate::errors::ApiError;
 use crate::schema::{library_items, library_items::dsl::library_items as all_library_items};
@@ -66,20 +65,20 @@ impl LibraryItemUpdateSpec {
 }
 
 impl LibraryItem {
-    pub fn find_all(conn: &PgConnection, session: Session) -> Result<Vec<LibraryItem>, ApiError> {
+    pub fn find_all(conn: &PgConnection, user_id: i32) -> Result<Vec<LibraryItem>, ApiError> {
         Ok(all_library_items
-            .filter(library_items::user_id.eq(session.user_id))
+            .filter(library_items::user_id.eq(user_id))
             .load(conn)
             .map_err(ApiError::DatabaseError)?)
     }
 
     pub fn find(
         conn: &PgConnection,
-        session: Session,
+        user_id: i32,
         api_id: String,
     ) -> Result<LibraryItem, ApiError> {
         Ok(all_library_items
-            .filter(library_items::user_id.eq(session.user_id))
+            .filter(library_items::user_id.eq(user_id))
             .filter(library_items::api_id.eq(api_id))
             .first::<LibraryItem>(conn)
             .map_err(ApiError::DatabaseError)?)
@@ -96,15 +95,16 @@ impl LibraryItem {
     }
 
     pub fn update(
-        session: Session,
         conn: &PgConnection,
+        user_id: i32,
         api_id: String,
         name: Option<String>,
     ) -> Result<LibraryItem, ApiError> {
+        // TODO: handle generating new upload URL (if needed)
         LibraryItemUpdateSpec {
             updated_at: Utc::now(),
             name,
         }
-        .update(conn, api_id, session.user_id)
+        .update(conn, api_id, user_id)
     }
 }

--- a/core/src/library/models/library_item_version.rs
+++ b/core/src/library/models/library_item_version.rs
@@ -22,7 +22,7 @@ pub struct LibraryItemVersion {
     pub library_item_id: i32,
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>,
-    #[serde(rename = "version_type")]
+    #[serde(rename = "versionType")]
     pub version_type: String,
     #[serde(rename = "assetUrl")]
     pub asset_url: Option<String>,

--- a/core/src/library/models/library_item_version_type.rs
+++ b/core/src/library/models/library_item_version_type.rs
@@ -4,14 +4,12 @@ use diesel::sql_types::Text;
 use diesel::Expression;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum JobStatus {
-    Pending,
-    Active,
-    Error,
-    Done,
+pub enum LibraryItemVersionType {
+    Original,
+    PreviewImage,
 }
 
-impl fmt::Display for JobStatus {
+impl fmt::Display for LibraryItemVersionType {
     // TODO: write macro to add Debug and this impl? or improve in some other way
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let type_str = format!("{:?}", self);
@@ -19,6 +17,6 @@ impl fmt::Display for JobStatus {
     }
 }
 
-impl Expression for JobStatus {
+impl Expression for LibraryItemVersionType {
     type SqlType = Text;
 }

--- a/core/src/library/models/mod.rs
+++ b/core/src/library/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod library_item;
 pub mod library_item_version;
+pub mod library_item_version_type;

--- a/core/src/notes/models/note.rs
+++ b/core/src/notes/models/note.rs
@@ -103,6 +103,7 @@ fn create_version_for_note_and_commit(
             let note_version = NoteVersion::create(conn, note_.id, content_data);
             if let Ok(created_note_version) = note_version {
                 // TODO: log note version creation
+                // TODO: move transaction handling out of this fn
                 commit_txn(conn).unwrap();
                 Ok(Note {
                     api_id: note_.api_id,
@@ -114,6 +115,7 @@ fn create_version_for_note_and_commit(
                 })
             } else {
                 // TODO: handle failure
+                // TODO: move transaction handling out of this fn
                 rollback_txn(conn).unwrap();
                 Err(ApiError::InternalError(
                     "Failed to create note version".to_string(),
@@ -130,6 +132,7 @@ fn create_version_for_note_and_commit(
             })
         }
     } else {
+        // TODO: move transaction handling out of this fn
         rollback_txn(conn).unwrap();
         Err(ApiError::InternalError("Failed to create note".to_string()))
     }
@@ -179,6 +182,7 @@ impl Note {
         session: Session,
         content: Option<serde_json::Value>,
     ) -> Result<Note, ApiError> {
+        // TODO: move transaction handling out of this fn
         begin_txn(conn).unwrap();
         let note_result = NoteCreateSpec {
             api_id: generate_resource_identifier(ResourceType::Note),
@@ -196,6 +200,7 @@ impl Note {
         name: Option<String>,
         updated_content: Option<serde_json::Value>,
     ) -> Result<Note, ApiError> {
+        // TODO: move transaction handling out of this fn
         begin_txn(conn).unwrap();
         let note_result = NoteUpdateSpec {
             updated_at: Utc::now(),

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -18,7 +18,10 @@ table! {
         user_id -> Int4,
         library_item_id -> Int4,
         created_at -> Timestamptz,
-        asset_url -> Varchar,
+        version_type -> Varchar,
+        asset_url -> Nullable<Varchar>,
+        asset_file_size_bytes -> Nullable<Int8>,
+        asset_data -> Nullable<Jsonb>,
     }
 }
 

--- a/tests/src/tests/db/job_subscription.rs
+++ b/tests/src/tests/db/job_subscription.rs
@@ -7,7 +7,7 @@ fn test_enqueued_job_is_completed(pool: &DbPool) {
     let conn = get_conn(pool).unwrap();
     let _tasks = Job::create(
         &conn,
-        JobType::SYSTEM,
+        JobType::System,
         Some(serde_json::from_str("{}").unwrap()),
         None,
     );

--- a/web-client/src/library/LibraryItemList.tsx
+++ b/web-client/src/library/LibraryItemList.tsx
@@ -19,8 +19,7 @@ function LibraryItemList(): h.JSX.Element {
                 allowMultiple={true}
                 onChange={(ev: Event): void => {
                     const files = Array.from((ev.target as HTMLInputElement).files ?? []);
-                    const response = bulkCreateLibraryItems(authContext, files);
-                    console.log(response);
+                    bulkCreateLibraryItems(authContext, files);
                 }}
             />
         </AppContainer>

--- a/web-client/src/models/LibraryItem.ts
+++ b/web-client/src/models/LibraryItem.ts
@@ -24,3 +24,11 @@ export interface LibraryItem extends ApiLibraryItemSummary {
     tags?: Array<Tag>;
     resources?: Array<Resource>;
 }
+
+export interface ApiLibraryItemVersion {
+    id: string;
+    createdAt: Date;
+    versionType: string;
+    assetUrl: string;
+    assetFileSizeBytes: number;
+}


### PR DESCRIPTION
add API endpoint — `library-item-version` (`POST`), then call that from the front-end when a file upload to S3 completes