### PR TITLE
[be] yield to tokio runtime when running sync I/O

### DIFF
--- a/api_server/Cargo.toml
+++ b/api_server/Cargo.toml
@@ -15,6 +15,6 @@ diesel_migrations = "^1.4"
 dotenv = "^0.14"
 log = "^0.4"
 pretty_env_logger = "^0.3"
-tokio = { version = "^0.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "^0.2", features = ["blocking", "macros", "rt-threaded"] }
 warp = "^0.2"
 world_core = { path = "../core" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,7 +29,7 @@ rusoto_sts = "^0.45"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
-tokio = { version = "^0.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "^0.2", features = ["blocking", "macros", "rt-threaded"] }
 warp = "^0.2"
 flame = "^0.2"
 flamescope = "^0.1"

--- a/core/src/auth/handlers.rs
+++ b/core/src/auth/handlers.rs
@@ -1,4 +1,5 @@
 use serde_json::json;
+use tokio::task::block_in_place;
 use warp::http::StatusCode;
 use warp::Rejection;
 
@@ -59,28 +60,36 @@ pub async fn sign_in(
     db_pool: DbPool,
 ) -> Result<impl warp::Reply, Rejection> {
     debug!("sign_in: email_address={}", sign_in_request.email_address);
-    let response = run_sign_in(sign_in_request, &db_pool)?;
+    let response = block_in_place(move || run_sign_in(sign_in_request, &db_pool))?;
     Ok(warp::reply::with_status(
         warp::reply::json(&response),
         StatusCode::OK,
     ))
 }
 
+fn run_sign_up(
+    create_spec: ApiUserCreateSpec,
+    pool: &DbPool,
+) -> Result<AuthenticationResponse, ApiError> {
+    let user = User::create(create_spec, &get_conn(&pool).unwrap())?;
+    Ok(AuthenticationResponse {
+        user: Some(user),
+        session: None, // TODO: create session upon sign-up
+        error: None,
+    })
+}
+
 pub async fn sign_up(
-    new_user: ApiUserCreateSpec,
-    db_pool: DbPool,
+    create_spec: ApiUserCreateSpec,
+    pool: DbPool,
 ) -> Result<impl warp::Reply, Rejection> {
     debug!(
         "sign_up: email_address={}, full_name={:?}",
-        new_user.email_address, new_user.full_name
+        create_spec.email_address, create_spec.full_name
     );
-    let user = User::create(new_user, &get_conn(&db_pool).unwrap())?;
+    let response = block_in_place(move || run_sign_up(create_spec, &pool))?;
     Ok(warp::reply::with_status(
-        warp::reply::json(&AuthenticationResponse {
-            user: Some(user),
-            session: None, // TODO: create session upon sign-up
-            error: None,
-        }),
+        warp::reply::json(&response),
         StatusCode::OK,
     ))
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,7 +19,6 @@ pub mod s3;
 pub mod schema;
 pub mod utils;
 
-// TODO: move DB operations to an async thread pool (tokio?)
 pub mod auth;
 pub mod library;
 pub mod notes;

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -20,7 +20,7 @@ pretty_env_logger = "^0.3"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
-tokio = { version = "^0.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "^0.2", features = ["blocking", "macros", "rt-threaded"] }
 warp = "^0.2"
 world_core = { path = "../core" }
 fallible-iterator="0.1.6" # higher versions don't work with postgres


### PR DESCRIPTION
wrap queries with `tokio::task::block_in_place`