### PR TITLE
chore: bump rust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.46-slim-buster
+FROM rust:1.48-slim-buster
 
 COPY ./scripts/* /
 RUN bash /setup_test_env.sh


### PR DESCRIPTION
1.46 -> 1.48